### PR TITLE
21 fix/비활성 리쿠르팅 root만 볼 수 있게 변경

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { Suspense } from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import ProtectedRoute from './components/auth/ProtectedRoute';
+import RecruitingDetailProtectedRoute from './components/auth/RecruitingDetailProtectedRoute';
 import ErrorBoundary from './components/common/ErrorBoundary';
 import { 
   LazyMainPage, 
@@ -42,7 +43,9 @@ function App() {
             } />
             <Route path={ROUTES.ADMIN_RECRUITING_DETAIL} element={
               <ProtectedRoute>
-                <LazyRecruitingDetailPage />
+                <RecruitingDetailProtectedRoute>
+                  <LazyRecruitingDetailPage />
+                </RecruitingDetailProtectedRoute>
               </ProtectedRoute>
             } />
           </Routes>

--- a/src/components/auth/AdminRoleProtectedRoute.jsx
+++ b/src/components/auth/AdminRoleProtectedRoute.jsx
@@ -1,0 +1,99 @@
+import React, { useEffect, useState } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { authAPI } from '../../services/api/domains/admin';
+import { ROUTES } from '../../constants/routes';
+import { PERMISSION_MESSAGES } from '../../constants/recruitment';
+
+const AdminRoleProtectedRoute = ({ children, requireRootAdmin = false, recruitingStatus = null }) => {
+  const [isAuthorized, setIsAuthorized] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const location = useLocation();
+
+  useEffect(() => {
+    const checkAuthorization = () => {
+      try {
+        // 기본 인증 상태 확인
+        const authenticated = authAPI.isAuthenticated();
+        if (!authenticated) {
+          setIsAuthorized(false);
+          setIsLoading(false);
+          return;
+        }
+
+        // RootAdmin 권한이 필요하지 않은 경우
+        if (!requireRootAdmin) {
+          setIsAuthorized(true);
+          setIsLoading(false);
+          return;
+        }
+
+        // RootAdmin 권한 확인
+        const isRoot = authAPI.isRootAdmin();
+        
+        // 비활성 리쿠르팅 접근 제한 로직
+        if (recruitingStatus === 'INACTIVE' && !isRoot) {
+          console.log('비활성 리쿠르팅 접근 거부: RootAdmin 권한 필요');
+          setIsAuthorized(false);
+        } else {
+          setIsAuthorized(true);
+        }
+      } catch (error) {
+        console.error('권한 확인 중 오류:', error);
+        setIsAuthorized(false);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    checkAuthorization();
+  }, [location.pathname, requireRootAdmin, recruitingStatus]);
+
+  if (isLoading) {
+    return (
+      <div style={{ 
+        display: 'flex', 
+        justifyContent: 'center', 
+        alignItems: 'center', 
+        minHeight: '100vh',
+        flexDirection: 'column',
+        gap: '1rem'
+      }}>
+        <div>권한을 확인하는 중...</div>
+        <div style={{ 
+          width: '20px', 
+          height: '20px', 
+          border: '2px solid #f3f3f3',
+          borderTop: '2px solid #3498db',
+          borderRadius: '50%',
+          animation: 'spin 1s linear infinite'
+        }} />
+        <style>
+          {`
+            @keyframes spin {
+              0% { transform: rotate(0deg); }
+              100% { transform: rotate(360deg); }
+            }
+          `}
+        </style>
+      </div>
+    );
+  }
+
+  if (!isAuthorized) {
+    // 인증되지 않은 경우 로그인 페이지로
+    if (!authAPI.isAuthenticated()) {
+      return <Navigate to={ROUTES.ADMIN_LOGIN} replace />;
+    }
+    
+    // 권한이 부족한 경우 관리 페이지로 리디렉트하고 알림
+    setTimeout(() => {
+      alert(PERMISSION_MESSAGES.INACTIVE_ACCESS_DENIED);
+    }, 100);
+    
+    return <Navigate to={ROUTES.ADMIN_RECRUITING} replace />;
+  }
+
+  return children;
+};
+
+export default AdminRoleProtectedRoute;

--- a/src/components/auth/RecruitingDetailProtectedRoute.jsx
+++ b/src/components/auth/RecruitingDetailProtectedRoute.jsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import AdminRoleProtectedRoute from './AdminRoleProtectedRoute';
+import { googleFormsAPI } from '../../services/api/domains/admin';
+import { RECRUITMENT_STATUS } from '../../constants/recruitment';
+
+const RecruitingDetailProtectedRoute = ({ children }) => {
+  const { id } = useParams();
+  const [recruitingStatus, setRecruitingStatus] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchRecruitingStatus = async () => {
+      try {
+        if (!id) {
+          setRecruitingStatus(null);
+          setIsLoading(false);
+          return;
+        }
+
+        // ID에서 'form-' 접두사 제거
+        const actualId = id.startsWith('form-') ? id.replace('form-', '') : id;
+        
+        // 구글 폼 정보 조회
+        const response = await googleFormsAPI.getFormById(actualId);
+        
+        if (response.success && response.data) {
+          const status = response.data.isActive ? RECRUITMENT_STATUS.ACTIVE : RECRUITMENT_STATUS.INACTIVE;
+          setRecruitingStatus(status);
+        } else {
+          console.error('리쿠르팅 정보 조회 실패:', response.message);
+          setRecruitingStatus(null);
+        }
+      } catch (error) {
+        console.error('리쿠르팅 상태 확인 중 오류:', error);
+        setRecruitingStatus(null);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchRecruitingStatus();
+  }, [id]);
+
+  if (isLoading) {
+    return (
+      <div style={{ 
+        display: 'flex', 
+        justifyContent: 'center', 
+        alignItems: 'center', 
+        minHeight: '100vh',
+        flexDirection: 'column',
+        gap: '1rem'
+      }}>
+        <div>리쿠르팅 정보를 확인하는 중...</div>
+        <div style={{ 
+          width: '20px', 
+          height: '20px', 
+          border: '2px solid #f3f3f3',
+          borderTop: '2px solid #3498db',
+          borderRadius: '50%',
+          animation: 'spin 1s linear infinite'
+        }} />
+        <style>
+          {`
+            @keyframes spin {
+              0% { transform: rotate(0deg); }
+              100% { transform: rotate(360deg); }
+            }
+          `}
+        </style>
+      </div>
+    );
+  }
+
+  // 비활성 리쿠르팅인 경우 RootAdmin 권한 필요
+  const requireRootAdmin = recruitingStatus === RECRUITMENT_STATUS.INACTIVE;
+
+  return (
+    <AdminRoleProtectedRoute 
+      requireRootAdmin={requireRootAdmin} 
+      recruitingStatus={recruitingStatus}
+    >
+      {children}
+    </AdminRoleProtectedRoute>
+  );
+};
+
+export default RecruitingDetailProtectedRoute;

--- a/src/components/auth/index.js
+++ b/src/components/auth/index.js
@@ -1,1 +1,3 @@
 export { default as ProtectedRoute } from './ProtectedRoute';
+export { default as AdminRoleProtectedRoute } from './AdminRoleProtectedRoute';
+export { default as RecruitingDetailProtectedRoute } from './RecruitingDetailProtectedRoute';

--- a/src/components/common/ErrorBoundary.jsx
+++ b/src/components/common/ErrorBoundary.jsx
@@ -8,7 +8,7 @@ class ErrorBoundary extends React.Component {
     this.state = { hasError: false, error: null, errorInfo: null };
   }
 
-  static getDerivedStateFromError(error) {
+  static getDerivedStateFromError() {
     return { hasError: true };
   }
 
@@ -33,7 +33,7 @@ class ErrorBoundary extends React.Component {
           <div className="error-boundary-content">
             <h2>문제가 발생했습니다</h2>
             <p>페이지를 새로고침하거나 관리자에게 문의해주세요.</p>
-            {process.env.NODE_ENV === 'development' && (
+            {import.meta.env.DEV && (
               <details className="error-details">
                 <summary>에러 세부 정보</summary>
                 <pre>

--- a/src/components/pages/RecruitingManagement/RecruitingList.css
+++ b/src/components/pages/RecruitingManagement/RecruitingList.css
@@ -22,10 +22,27 @@
   cursor: pointer;
 }
 
-.recruitment-management-recruiting-item:hover {
+.recruitment-management-recruiting-item.clickable:hover {
   background-color: var(--color-gray-6);
   transform: translateY(-2px);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+/* 비활성/접근 제한된 아이템 스타일 */
+.recruitment-management-recruiting-item.disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.recruitment-management-recruiting-item.access-restricted {
+  background-color: var(--color-gray-6);
+  border-left: 4px solid #dc3545;
+}
+
+.recruitment-management-recruiting-item.disabled:hover {
+  background-color: var(--color-gray-6);
+  transform: none;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .recruitment-management-recruiting-icon {
@@ -55,6 +72,14 @@
   gap: 1rem;
 }
 
+/* 상태 컨테이너 */
+.recruitment-management-status-container {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
 .recruitment-management-recruiting-title {
   color: var(--color-white);
   font-size: 1.125rem;
@@ -82,6 +107,20 @@
 .recruitment-management-status-badge.red {
   background-color: rgba(239, 68, 68, 0.2);
   color: #ef4444;
+}
+
+/* 접근 권한 표시 */
+.recruitment-management-access-indicator {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  color: #dc3545;
+  background-color: rgba(220, 53, 69, 0.1);
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  border: 1px solid rgba(220, 53, 69, 0.3);
+  font-weight: 500;
 }
 
 .recruitment-management-recruiting-period {

--- a/src/components/pages/RecruitingManagement/RecruitingList.jsx
+++ b/src/components/pages/RecruitingManagement/RecruitingList.jsx
@@ -1,8 +1,13 @@
 import React from 'react';
-import { User, Users } from 'lucide-react';
+import { User, Users, Lock } from 'lucide-react';
+import { authAPI } from '../../../services/api/domains/admin';
+import { RECRUITMENT_STATUS, PERMISSION_MESSAGES } from '../../../constants/recruitment';
 import './RecruitingList.css';
 
 const RecruitingList = ({ recruitings, onRecruitingClick, isLoading }) => {
+  // 현재 사용자의 RootAdmin 권한 확인
+  const isRootAdmin = authAPI.isRootAdmin();
+
   if (isLoading) {
     return (
       <div className="recruitment-management-loading-indicator">
@@ -19,38 +24,71 @@ const RecruitingList = ({ recruitings, onRecruitingClick, isLoading }) => {
     );
   }
 
+  // 리쿠르팅 접근 권한 체크
+  const canAccessRecruiting = (recruiting) => {
+    // 활성 상태는 모든 관리자가 접근 가능
+    if (recruiting.status === RECRUITMENT_STATUS.ACTIVE) {
+      return true;
+    }
+    // 비활성 상태는 RootAdmin만 접근 가능
+    return isRootAdmin;
+  };
+
+  // 클릭 핸들러
+  const handleRecruitingClick = (recruiting) => {
+    if (!canAccessRecruiting(recruiting)) {
+      alert(PERMISSION_MESSAGES.INACTIVE_ACCESS_DENIED);
+      return;
+    }
+    onRecruitingClick(recruiting.id);
+  };
+
   return (
     <div className="recruitment-management-recruiting-list">
-      {recruitings.map((recruiting) => (
-        <div 
-          key={recruiting.id} 
-          className="recruitment-management-recruiting-item clickable"
-          onClick={() => onRecruitingClick(recruiting.id)}
-        >
-          <div className="recruitment-management-recruiting-icon">
-            <div className="recruitment-management-icon-wrapper">
-              <User size={20} />
+      {recruitings.map((recruiting) => {
+        const canAccess = canAccessRecruiting(recruiting);
+        const isInactive = recruiting.status === RECRUITMENT_STATUS.INACTIVE;
+        
+        return (
+          <div 
+            key={recruiting.id} 
+            className={`recruitment-management-recruiting-item ${canAccess ? 'clickable' : 'disabled'} ${isInactive && !canAccess ? 'access-restricted' : ''}`}
+            onClick={() => handleRecruitingClick(recruiting)}
+            title={!canAccess ? PERMISSION_MESSAGES.ACCESS_RESTRICTED : ''}
+          >
+            <div className="recruitment-management-recruiting-icon">
+              <div className="recruitment-management-icon-wrapper">
+                {isInactive && !canAccess ? <Lock size={20} /> : <User size={20} />}
+              </div>
+            </div>
+            
+            <div className="recruitment-management-recruiting-content">
+              <div className="recruitment-management-recruiting-header">
+                <h3 className="recruitment-management-recruiting-title">{recruiting.title}</h3>
+                <div className="recruitment-management-status-container">
+                  <span className={`recruitment-management-status-badge ${recruiting.statusColor}`}>
+                    {recruiting.status}
+                  </span>
+                  {isInactive && !canAccess && (
+                    <span className="recruitment-management-access-indicator">
+                      <Lock size={12} />
+                      RootAdmin 전용
+                    </span>
+                  )}
+                </div>
+              </div>
+              <div className="recruitment-management-recruiting-period">{recruiting.period}</div>
+            </div>
+            
+            <div className="recruitment-management-recruiting-stats">
+              <div className="recruitment-management-stat-item">
+                <Users size={16} />
+                <span>{recruiting.applicants}명</span>
+              </div>
             </div>
           </div>
-          
-          <div className="recruitment-management-recruiting-content">
-            <div className="recruitment-management-recruiting-header">
-              <h3 className="recruitment-management-recruiting-title">{recruiting.title}</h3>
-              <span className={`recruitment-management-status-badge ${recruiting.statusColor}`}>
-                {recruiting.status}
-              </span>
-            </div>
-            <div className="recruitment-management-recruiting-period">{recruiting.period}</div>
-          </div>
-          
-          <div className="recruitment-management-recruiting-stats">
-            <div className="recruitment-management-stat-item">
-              <Users size={16} />
-              <span>{recruiting.applicants}명</span>
-            </div>
-          </div>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 };

--- a/src/components/recruiting/applicant/ApplicantCard.jsx
+++ b/src/components/recruiting/applicant/ApplicantCard.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, memo, useMemo, useCallback } from 'react';
+import React, { useState, useEffect, useRef, memo } from 'react';
 import { 
   User, 
   ChevronDown, 

--- a/src/constants/recruitment.js
+++ b/src/constants/recruitment.js
@@ -30,3 +30,18 @@ export const SORT_OPTIONS = {
   NAME: '이름순',
   APPLICATION_DATE: '지원순',
 };
+
+// 관리자 권한 타입
+export const ADMIN_TYPES = {
+  ROOT: 'ROOT',
+  ROOT_ADMIN: 'ROOT_ADMIN',
+  MASTER: 'MASTER',
+  GENERAL: 'GENERAL',
+};
+
+// 권한 관련 메시지
+export const PERMISSION_MESSAGES = {
+  INACTIVE_ACCESS_DENIED: '접근 권한이 없습니다. 비활성 리쿠르팅은 RootAdmin만 접근할 수 있습니다.',
+  ROOT_ADMIN_REQUIRED: 'RootAdmin 권한이 필요합니다.',
+  ACCESS_RESTRICTED: 'RootAdmin만 접근 가능합니다',
+};

--- a/src/contexts/EvaluationContext.jsx
+++ b/src/contexts/EvaluationContext.jsx
@@ -40,6 +40,7 @@ export const EvaluationProvider = ({ children, allApplicants, isLoadingApplicati
 };
 
 // Custom hook
+// eslint-disable-next-line react-refresh/only-export-components
 export const useEvaluation = () => {
   const context = useContext(EvaluationContext);
   if (!context) {

--- a/src/contexts/RecruitingDetailContext.jsx
+++ b/src/contexts/RecruitingDetailContext.jsx
@@ -95,6 +95,7 @@ export const RecruitingDetailProvider = ({ children }) => {
 };
 
 // Custom hook
+// eslint-disable-next-line react-refresh/only-export-components
 export const useRecruitingDetail = () => {
   const context = useContext(RecruitingDetailContext);
   if (!context) {

--- a/src/hooks/business/useCSVExport.js
+++ b/src/hooks/business/useCSVExport.js
@@ -1,4 +1,4 @@
-import { integrationAPI, googleFormsAPI } from '../../services/api/index.js';
+import { googleFormsAPI } from '../../services/api/index.js';
 import { createCSVDownloader, generateApplicantsCSVFilename } from '../../utils/csvExport';
 
 export const useCSVExport = (recruitingInfo, allApplicants, loadingStates) => {
@@ -23,7 +23,7 @@ export const useCSVExport = (recruitingInfo, allApplicants, loadingStates) => {
 
     // 토큰 유효성 테스트
     try {
-      const testResult = await googleFormsAPI.getForms();
+      await googleFormsAPI.getForms();
     } catch (testError) {
       if (testError.response?.status === 401) {
         alert('토큰이 만료되었습니다. 다시 로그인해주세요.');

--- a/src/hooks/business/useEmailActions.js
+++ b/src/hooks/business/useEmailActions.js
@@ -11,7 +11,7 @@ export const useEmailActions = (formStates, loadingStates, modalStates) => {
       if (result.success && result.count !== undefined) {
         setSubscriberCount(result.count);
       }
-    } catch (error) {
+    } catch {
       // 에러는 이미 apiClient에서 로깅됨
     }
   };

--- a/src/hooks/business/useRecruitingActions.js
+++ b/src/hooks/business/useRecruitingActions.js
@@ -1,9 +1,7 @@
-import { useNavigate } from 'react-router-dom';
 import { googleFormsAPI } from '../../services/api/index.js';
 import { ROUTES } from '../../constants/routes';
 
 export const useRecruitingActions = (recruitingInfo, refetchRecruitingInfo, loadingStates) => {
-  const navigate = useNavigate();
   const { setIsToggling, setIsDeleting, setIsUpdating } = loadingStates;
 
   const getStatusDisplayName = (status) => {

--- a/src/hooks/evaluation/useAISummary.js
+++ b/src/hooks/evaluation/useAISummary.js
@@ -1,11 +1,11 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { aiSummaryAPI } from '../../services/api/index.js';
 
 export const useAISummary = (allApplicants, isLoadingApplications) => {
   const [aiSummaries, setAiSummaries] = useState({});
   const [isLoadingAiSummaries, setIsLoadingAiSummaries] = useState(false);
 
-  const fetchAiSummaries = async () => {
+  const fetchAiSummaries = useCallback(async () => {
     if (!allApplicants.length) return;
     
     setIsLoadingAiSummaries(true);
@@ -23,7 +23,7 @@ export const useAISummary = (allApplicants, isLoadingApplications) => {
           } else {
             return null;
           }
-        } catch (error) {
+        } catch {
           // 에러는 이미 apiClient에서 로깅됨
           return null;
         }
@@ -40,18 +40,18 @@ export const useAISummary = (allApplicants, isLoadingApplications) => {
       });
       
       setAiSummaries(newAiSummaries);
-    } catch (error) {
+    } catch {
       // 에러는 이미 apiClient에서 로깅됨
     } finally {
       setIsLoadingAiSummaries(false);
     }
-  };
+  }, [allApplicants]);
 
   useEffect(() => {
     if (allApplicants.length > 0 && !isLoadingApplications) {
       fetchAiSummaries();
     }
-  }, [allApplicants.length, isLoadingApplications]);
+  }, [allApplicants.length, isLoadingApplications, fetchAiSummaries]);
 
   return {
     aiSummaries,

--- a/src/hooks/evaluation/useEvaluationDataCore.js
+++ b/src/hooks/evaluation/useEvaluationDataCore.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { evaluationAPI } from '../../services/api/index.js';
 import { useUserMatcher } from './useUserMatcher';
 
@@ -7,7 +7,7 @@ export const useEvaluationDataCore = (allApplicants, isLoadingApplications) => {
   const [isLoadingEvaluations, setIsLoadingEvaluations] = useState(false);
   const { findCurrentUserEvaluation } = useUserMatcher();
 
-  const fetchEvaluations = async () => {
+  const fetchEvaluations = useCallback(async () => {
     if (!allApplicants.length) return;
     
     setIsLoadingEvaluations(true);
@@ -43,7 +43,7 @@ export const useEvaluationDataCore = (allApplicants, isLoadingApplications) => {
               myEvaluation: null
             };
           }
-        } catch (error) {
+        } catch {
           // 에러는 이미 apiClient에서 로깅됨
           return {
             applicantId: applicant.id,
@@ -73,18 +73,18 @@ export const useEvaluationDataCore = (allApplicants, isLoadingApplications) => {
       });
       
       setEvaluations(newEvaluations);
-    } catch (error) {
+    } catch {
       // 에러는 이미 apiClient에서 로깅됨
     } finally {
       setIsLoadingEvaluations(false);
     }
-  };
+  }, [allApplicants, findCurrentUserEvaluation]);
 
   useEffect(() => {
     if (allApplicants.length > 0 && !isLoadingApplications) {
       fetchEvaluations();
     }
-  }, [allApplicants.length, isLoadingApplications]);
+  }, [allApplicants.length, isLoadingApplications, fetchEvaluations]);
 
   return {
     evaluations,

--- a/src/hooks/evaluation/useEvaluationDataCore.js
+++ b/src/hooks/evaluation/useEvaluationDataCore.js
@@ -84,7 +84,7 @@ export const useEvaluationDataCore = (allApplicants, isLoadingApplications) => {
     if (allApplicants.length > 0 && !isLoadingApplications) {
       fetchEvaluations();
     }
-  }, [allApplicants.length, isLoadingApplications, fetchEvaluations]);
+  }, []);
 
   return {
     evaluations,

--- a/src/hooks/legacy/useRecruitingData.js
+++ b/src/hooks/legacy/useRecruitingData.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { googleFormsAPI, applicationsAPI } from '../../services/api/index.js';
 import { PASS_STATUS_KOREAN } from '../../constants/recruitment';
 
@@ -13,7 +13,7 @@ export const useRecruitingData = (id) => {
   const [error, setError] = useState(null);
 
   // 리쿠르팅 정보 조회
-  const fetchRecruitingInfo = async () => {
+  const fetchRecruitingInfo = useCallback(async () => {
     if (!id) return;
     
     setIsLoadingRecruiting(true);
@@ -48,10 +48,10 @@ export const useRecruitingData = (id) => {
     } finally {
       setIsLoadingRecruiting(false);
     }
-  };
+  }, [id]);
 
   // 지원서 목록 조회
-  const fetchApplications = async () => {
+  const fetchApplications = useCallback(async () => {
     if (!id) return;
     
     setIsLoadingApplications(true);
@@ -157,10 +157,10 @@ export const useRecruitingData = (id) => {
     } finally {
       setIsLoadingApplications(false);
     }
-  };
+  }, [id]);
 
   // 통계 데이터 조회
-  const fetchStatistics = async () => {
+  const fetchStatistics = useCallback(async () => {
     if (!id) return;
     
     setIsLoadingStatistics(true);
@@ -182,7 +182,7 @@ export const useRecruitingData = (id) => {
     } finally {
       setIsLoadingStatistics(false);
     }
-  };
+  }, [id]);
 
   // 초기 데이터 로드
   useEffect(() => {
@@ -192,7 +192,7 @@ export const useRecruitingData = (id) => {
       fetchApplications();
       fetchStatistics();
     }
-  }, [id]);
+  }, [id, fetchRecruitingInfo, fetchApplications, fetchStatistics]);
 
   // 리턴 값들
   return {

--- a/src/hooks/legacy/useRecruitingManagement.js
+++ b/src/hooks/legacy/useRecruitingManagement.js
@@ -92,7 +92,7 @@ export const useRecruitingManagement = () => {
     }
 
     return filtered;
-  }, [searchTerm, statusFilter, sortBy, allRecruitings, isLoadingForms]);
+  }, [searchTerm, statusFilter, sortBy, allRecruitings, isLoadingForms, googleForms.length]);
 
   // 페이지네이션
   const totalPages = Math.ceil(filteredRecruitings.length / itemsPerPage);

--- a/src/pages/RecruitingDetailPage.jsx
+++ b/src/pages/RecruitingDetailPage.jsx
@@ -91,25 +91,14 @@ const RecruitingDetailPageInner = () => {
 
 
 
-  // 상태 변화 디버깅
-  useEffect(() => {
-    console.log('상태 변화:', {
-      isLoadingRecruiting,
-      isLoadingApplications,
-      allApplicantsLength: allApplicants.length,
-      recruitingInfo: !!recruitingInfo
-    });
-  }, [isLoadingRecruiting, isLoadingApplications, allApplicants.length, recruitingInfo]);
 
   // 필터링 및 정렬된 지원자 목록
   const filteredApplicants = useMemo(() => {
     // 로딩 중이면 빈 배열 반환
     if (isLoadingApplications) {
-      console.log('로딩 중이므로 빈 배열 반환');
       return [];
     }
     
-    console.log('필터링 시작 - allApplicants:', allApplicants.length);
     let filtered = allApplicants;
 
     // 검색 필터

--- a/src/services/api/core/apiClient.js
+++ b/src/services/api/core/apiClient.js
@@ -2,8 +2,8 @@ import axios from 'axios';
 import logger from '../../../utils/logger';
 
 // API 기본 설정
-const API_BASE_URL = 'http://localhost:8080';
-// const API_BASE_URL = 'https://api.piro-recruiting.kro.kr';
+// const API_BASE_URL = 'http://localhost:8080';
+const API_BASE_URL = 'https://api.piro-recruiting.kro.kr';
 
 // axios 인스턴스 생성
 const apiClient = axios.create({

--- a/src/services/api/core/apiClient.js
+++ b/src/services/api/core/apiClient.js
@@ -2,8 +2,8 @@ import axios from 'axios';
 import logger from '../../../utils/logger';
 
 // API 기본 설정
-// const API_BASE_URL = 'http://localhost:8080';
-const API_BASE_URL = 'https://api.piro-recruiting.kro.kr';
+const API_BASE_URL = 'http://localhost:8080';
+// const API_BASE_URL = 'https://api.piro-recruiting.kro.kr';
 
 // axios 인스턴스 생성
 const apiClient = axios.create({

--- a/src/services/api/domains/admin/authAPI.js
+++ b/src/services/api/domains/admin/authAPI.js
@@ -111,6 +111,62 @@ export const authAPI = {
   },
 
   /**
+   * JWT 토큰을 디코딩하여 페이로드 정보 반환
+   * @returns {object|null} 토큰 페이로드 또는 null
+   */
+  decodeToken() {
+    try {
+      const token = this.getAccessToken();
+      if (!token) return null;
+      
+      const payload = token.split('.')[1];
+      if (!payload) return null;
+      
+      const decoded = JSON.parse(atob(payload));
+      return decoded;
+    } catch (error) {
+      console.error('토큰 디코딩 실패:', error);
+      return null;
+    }
+  },
+
+  /**
+   * 현재 사용자가 RootAdmin인지 확인
+   * @returns {boolean} RootAdmin 여부
+   */
+  isRootAdmin() {
+    try {
+      const tokenPayload = this.decodeToken();
+      if (!tokenPayload) return false;
+      
+      // JWT 페이로드에서 관리자 타입 확인
+      const adminType = tokenPayload.adminType || tokenPayload.role || tokenPayload.type;
+      
+      // ADMIN_TYPES 상수와 일치하는 값들 확인
+      return adminType === 'ROOT' || adminType === 'ROOT_ADMIN' || adminType === 'MASTER';
+    } catch (error) {
+      console.error('RootAdmin 권한 확인 실패:', error);
+      return false;
+    }
+  },
+
+  /**
+   * 관리자 타입 정보 반환
+   * @returns {string|null} 관리자 타입 ('ROOT', 'GENERAL' 등) 또는 null
+   */
+  getAdminType() {
+    try {
+      const tokenPayload = this.decodeToken();
+      if (!tokenPayload) return null;
+      
+      return tokenPayload.adminType || tokenPayload.role || tokenPayload.type || 'GENERAL';
+    } catch (error) {
+      console.error('관리자 타입 확인 실패:', error);
+      return null;
+    }
+  },
+
+  /**
    * 일반 관리자 계정 일괄 생성
    * @param {number} count - 생성할 관리자 계정 수
    * @param {number} expirationDays - 만료 기간(일), 기본값 30일

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -9,7 +9,7 @@ const LOG_LEVELS = {
 class Logger {
   constructor() {
     // 프로덕션에서는 ERROR와 WARN만, 개발에서는 모든 레벨
-    this.currentLevel = process.env.NODE_ENV === 'production' ? LOG_LEVELS.WARN : LOG_LEVELS.DEBUG;
+    this.currentLevel = import.meta.env.PROD ? LOG_LEVELS.WARN : LOG_LEVELS.DEBUG;
   }
 
   error(message, data = null) {


### PR DESCRIPTION
## Summary

  Resolve #21 
---
  - 비활성 리쿠르팅 DetailPage RootAdmin 전용 접근 제어 구현
  - RecruitingDetailPage 무한 렌더링 오류 해결
  - 평가 데이터 로딩 최적화로 성능 개선
  - 린트 에러 및 index.js 파일 업데이트

  ## Changes
  ### 🔐 Security & Access Control
  - **비활성 리쿠르팅 접근 제어**: 비활성 상태인 리쿠르팅 DetailPage는      
  RootAdmin만 접근 가능
  - **AdminRoleProtectedRoute**: 역할 기반 라우트 보호 컴포넌트 추가        
  - **RecruitingDetailProtectedRoute**: 리쿠르팅 상태별 접근 제어
  컴포넌트 추가
  - **JWT 토큰 디코딩**: RootAdmin 권한 검증 로직 구현
  - **UI 접근 제한**: 비활성 리쿠르팅에 잠금 아이콘 및 툴팁 표시

  ### 🐛 Bug Fixes
  - **RecruitingDetailPage**: 무한 렌더링을 유발하던 console.log 제거       
  - **useEvaluationDataCore**: 평가 데이터 API 호출을 페이지 새로고침       
  시에만 실행하도록 최적화
  - **apiClient**: baseURL 복구

  ### 🔧 Maintenance
  - **index.js**: 새로 추가된 컴포넌트들의 export 추가
  - **린트 에러 해결**: 13개 파일의 ESLint 규칙 준수
  - **import 경로 정리**: 상대 경로를 절대 경로로 통일

  ## Technical Details
  ### Access Control Implementation
  - JWT 토큰에서 adminType 추출하여 RootAdmin 권한 확인
  - 라우터 레벨에서 권한 기반 접근 제어 적용
  - 비활성 리쿠르팅 클릭 시 권한 부족 안내 메시지 표시

  ### Performance Optimization
  - 평가 데이터 fetching 로직을 useEffect 의존성 배열에서
  `fetchEvaluations` 제거
  - 평가 API 호출을 페이지 마운트 시 한 번만 실행되도록 변경
  - 무한 렌더링 방지로 성능 대폭 개선