### PR TITLE
feat: 지원서 상태 변경 UI 개선 및 점수 표시 시스템 개선

### DIFF
--- a/appilcant-api.md
+++ b/appilcant-api.md
@@ -1,0 +1,305 @@
+구글 폼별 지원서 일괄 상태 변경 API 명세서
+
+  개요
+
+  특정 구글 폼의 지원자들 중 평가 점수 기준 상위/하위 N명의 합격 상태를 일괄 변경하는 API입니다. Root 관리자 권한이 필요합니다.
+
+  API 엔드포인트
+
+  1. 구글 폼별 점수 상위 N명 상태 변경
+
+  POST /api/webhook/applications/google-form/{googleFormId}/bulk-status
+
+  특정 구글 폼의 평가 점수 상위 N명의 지원서 합격 상태를 일괄 변경합니다.
+
+  권한
+
+  - @RequireRoot - Root 관리자 권한 필요
+
+  경로 파라미터
+
+  | 파라미터         | 타입   | 필수  | 설명      | 예시  |
+  |--------------|------|-----|---------|-----|
+  | googleFormId | Long | ✅   | 구글 폼 ID | 1   |
+
+  요청 파라미터
+
+  | 파라미터       | 타입      | 필수  | 설명          | 예시         |
+  |------------|---------|-----|-------------|------------|
+  | topN       | Integer | ✅   | 변경할 상위 인원 수 | 20         |
+  | passStatus | String  | ✅   | 변경할 합격 상태   | FIRST_PASS |
+
+  선택 기준
+
+  - 대상: 해당 구글 폼의 지원서 중 평균 점수(averageScore)가 존재하고 평가 개수(evaluationCount) > 0인 지원서만
+  - 정렬: 평균 점수 내림차순 (ORDER BY averageScore DESC)
+  - 선택: 정렬된 결과에서 상위 N개 선택 (즉, 점수가 가장 높은 N명)
+
+  2. 구글 폼별 점수 하위 N명 상태 변경
+
+  POST /api/webhook/applications/google-form/{googleFormId}/bulk-status-bottom
+
+  특정 구글 폼의 평가 점수 하위 N명의 지원서 합격 상태를 일괄 변경합니다.
+
+  권한
+
+  - @RequireRoot - Root 관리자 권한 필요
+
+  경로 파라미터
+
+  | 파라미터         | 타입   | 필수  | 설명      | 예시  |
+  |--------------|------|-----|---------|-----|
+  | googleFormId | Long | ✅   | 구글 폼 ID | 1   |
+
+  요청 파라미터
+
+  | 파라미터       | 타입      | 필수  | 설명          | 예시     |
+  |------------|---------|-----|-------------|--------|
+  | bottomN    | Integer | ✅   | 변경할 하위 인원 수 | 10     |
+  | passStatus | String  | ✅   | 변경할 합격 상태   | FAILED |
+
+  선택 기준
+
+  - 대상: 해당 구글 폼의 지원서 중 평균 점수(averageScore)가 존재하고 평가 개수(evaluationCount) > 0인 지원서만
+  - 정렬: 평균 점수 오름차순 (ORDER BY averageScore ASC)
+  - 선택: 정렬된 결과에서 상위 N개 선택 (즉, 점수가 가장 낮은 N명)
+
+  공통 사항
+
+  요청 헤더
+
+  Authorization: Bearer {JWT_TOKEN}
+
+  합격 상태 값
+
+  | 상태         | 설명     | CSV 값 | 주요 사용 케이스  |
+  |------------|--------|-------|------------|
+  | PENDING    | 대기중/미정 | 0     | 상태 초기화     |
+  | FAILED     | 불합격    | 0     | 하위권 불합격 처리 |
+  | FIRST_PASS | 1차 합격  | 1     | 상위권 1차 통과  |
+  | FINAL_PASS | 최종 합격  | 2     | 최종 합격자 선정  |
+
+  응답 형식
+
+  성공 응답
+
+  HTTP Status: 200 OK
+
+  {
+    "success": true,
+    "data": [
+      {
+        "id": 25,
+        "applicantName": "김우수",
+        "applicantEmail": "top@example.com",
+        "school": "서울대학교",
+        "department": "컴퓨터공학과",
+        "grade": "3학년",
+        "major": "전공자",
+        "phoneNumber": "010-1234-5678",
+        "formResponseId": "response_top_001",
+        "submissionTimestamp": "2024-01-15T14:30:00",
+        "status": "COMPLETED",
+        "passStatus": "FIRST_PASS",
+        "averageScore": 92.5,
+        "evaluationCount": 4,
+        "homepageUserId": 1025,
+        "googleFormId": 1,
+        "createdAt": "2024-01-15T14:30:00",
+        "updatedAt": "2024-01-16T15:45:00"
+      },
+      {
+        "id": 18,
+        "applicantName": "박최고",
+        "applicantEmail": "excellent@example.com",
+        "school": "KAIST",
+        "department": "전산학부",
+        "grade": "4학년",
+        "major": "전공자",
+        "phoneNumber": "010-2345-6789",
+        "formResponseId": "response_top_002",
+        "submissionTimestamp": "2024-01-12T11:20:00",
+        "status": "COMPLETED",
+        "passStatus": "FIRST_PASS",
+        "averageScore": 89.3,
+        "evaluationCount": 3,
+        "homepageUserId": 1018,
+        "googleFormId": 1,
+        "createdAt": "2024-01-12T11:20:00",
+        "updatedAt": "2024-01-16T15:45:00"
+      }
+    ],
+    "message": "구글 폼 1의 상위 20명의 지원서 상태가 FIRST_PASS로 변경되었습니다.",
+    "status": 200,
+    "code": "SUCCESS",
+    "time": "2024-01-16T15:45:30"
+  }
+
+  오류 응답
+
+  HTTP Status: 400 Bad Request - 잘못된 파라미터
+  {
+    "success": false,
+    "data": null,
+    "message": "topN 파라미터는 필수입니다",
+    "status": 400,
+    "code": "VALIDATION_ERROR",
+    "time": "2024-01-16T15:45:30"
+  }
+
+  HTTP Status: 401 Unauthorized - 인증 필요
+  {
+    "success": false,
+    "data": null,
+    "message": "인증이 필요합니다",
+    "status": 401,
+    "code": "UNAUTHORIZED",
+    "time": "2024-01-16T15:45:30"
+  }
+
+  HTTP Status: 403 Forbidden - 권한 부족
+  {
+    "success": false,
+    "data": null,
+    "message": "Root 권한이 필요합니다",
+    "status": 403,
+    "code": "ACCESS_DENIED",
+    "time": "2024-01-16T15:45:30"
+  }
+
+  HTTP Status: 404 Not Found - 구글 폼 없음
+  {
+    "success": false,
+    "data": null,
+    "message": "구글 폼을 찾을 수 없습니다",
+    "status": 404,
+    "code": "GOOGLE_FORM_NOT_FOUND",
+    "time": "2024-01-16T15:45:30"
+  }
+
+  사용 예시
+
+  1. 25기 상위 20명을 1차 합격 처리
+
+  curl -X POST "http://localhost:8080/api/webhook/applications/google-form/1/bulk-status?topN=20&passStatus=FIRST_PASS" \
+    -H "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9..."
+
+  2. 25기 하위 15명을 불합격 처리
+
+  curl -X POST "http://localhost:8080/api/webhook/applications/google-form/1/bulk-status-bottom?bottomN=15&passStatus=FAILED" \
+    -H "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9..."
+
+  3. 26기 상위 10명을 최종 합격 처리
+
+  curl -X POST "http://localhost:8080/api/webhook/applications/google-form/2/bulk-status?topN=10&passStatus=FINAL_PASS" \
+    -H "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9..."
+
+  4. JavaScript fetch 예시 - 상위 N명 1차 합격
+
+  const updateTopNToFirstPass = async (googleFormId, topN) => {
+    try {
+      const response = await fetch(`/api/webhook/applications/google-form/${googleFormId}/bulk-status?topN=${topN}&passStatus=FIRST_PASS`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${jwtToken}`
+        }
+      });
+
+      const result = await response.json();
+
+      if (result.success) {
+        console.log(`구글 폼 ${googleFormId}의 상위 ${result.data.length}명이 1차 합격 처리되었습니다.`);
+
+        // 점수 순으로 정렬된 결과 출력
+        result.data.forEach((app, index) => {
+          console.log(`${index + 1}위: ${app.applicantName} (${app.averageScore}점)`);
+        });
+      } else {
+        console.error('처리 실패:', result.message);
+      }
+    } catch (error) {
+      console.error('API 호출 실패:', error);
+    }
+  };
+
+  // 사용 예시
+  updateTopNToFirstPass(1, 20); // 25기 상위 20명 1차 합격
+
+  5. JavaScript fetch 예시 - 하위 N명 불합격
+
+  const updateBottomNToFailed = async (googleFormId, bottomN) => {
+    const confirmMessage = `정말로 구글 폼 ${googleFormId}의 하위 ${bottomN}명을 불합격 처리하시겠습니까?`;
+
+    if (!confirm(confirmMessage)) return;
+
+    try {
+      const response = await fetch(`/api/webhook/applications/google-form/${googleFormId}/bulk-status-bottom?bottomN=${bottomN}&passStatus=FAILED`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${jwtToken}`
+        }
+      });
+
+      const result = await response.json();
+
+      if (result.success) {
+        console.log(`구글 폼 ${googleFormId}의 하위 ${result.data.length}명이 불합격 처리되었습니다.`);
+
+        // 낮은 점수 순으로 출력
+        result.data.forEach((app, index) => {
+          console.log(`${app.applicantName}: ${app.averageScore}점 -> 불합격`);
+        });
+      } else {
+        console.error('처리 실패:', result.message);
+      }
+    } catch (error) {
+      console.error('API 호출 실패:', error);
+    }
+  };
+
+  // 사용 예시
+  updateBottomNToFailed(1, 10); // 25기 하위 10명 불합격
+
+  실제 운영 시나리오
+
+  시나리오 1: 1차 전형 결과 발표
+
+  # 1단계: 25기 상위 30명 1차 합격 처리
+  POST /api/webhook/applications/google-form/1/bulk-status?topN=30&passStatus=FIRST_PASS
+
+  # 2단계: 25기 하위 20명 불합격 처리
+  POST /api/webhook/applications/google-form/1/bulk-status-bottom?bottomN=20&passStatus=FAILED
+
+  # 3단계: 나머지는 대기 상태 유지 (별도 처리 불필요)
+
+  시나리오 2: 최종 합격자 선정
+
+  # 1차 합격자 중 상위 15명 최종 합격 처리
+  POST /api/webhook/applications/google-form/1/bulk-status?topN=15&passStatus=FINAL_PASS
+
+  시나리오 3: 재평가 후 상태 조정
+
+  # 하위 5명을 다시 대기 상태로 변경 (재평가 목적)
+  POST /api/webhook/applications/google-form/1/bulk-status-bottom?bottomN=5&passStatus=PENDING
+
+  주의사항
+
+  1. 구글 폼 단위 처리: 각 API는 지정된 구글 폼 내의 지원자들만 대상으로 합니다.
+  2. 평가 완료 지원서만: 평가 점수가 없는 지원서는 대상에서 제외됩니다.
+  3. Root 권한 필수: 일반 관리자는 사용할 수 없습니다.
+  4. 트랜잭션 보장: 모든 지원서가 성공적으로 변경되거나 전체 롤백됩니다.
+  5. N > 대상 개수: 요청한 N이 평가된 지원서 수보다 크면 실제 존재하는 모든 지원서를 처리합니다.
+  6. 빈 결과: 해당 구글 폼에 평가된 지원서가 없으면 빈 배열을 반환합니다.
+
+  관련 API
+
+  조회용 API들
+
+  - GET /api/webhook/applications/google-form/{googleFormId} - 구글 폼별 전체 지원자 조회
+  - GET /api/webhook/applications/google-form/{googleFormId}/by-pass-status - 구글 폼별 합격 상태별 조회
+  - GET /api/webhook/applications/google-form/{googleFormId}/pass-statistics - 구글 폼별 합격 통계
+
+  기타 상태 변경 API들
+
+  - POST /api/webhook/applications/{id}/status - 개별 지원서 상태 변경
+  - POST /api/webhook/applications/batch-status - 지정된 ID 목록 일괄 변경

--- a/src/components/pages/RecruitingDetail/detail/ApplicantCard.css
+++ b/src/components/pages/RecruitingDetail/detail/ApplicantCard.css
@@ -122,15 +122,9 @@
 }
 
 .recruiting-detail-applied-date,
-.recruiting-detail-applicant-score,
-.recruiting-detail-evaluation-score {
+.recruiting-detail-applicant-score {
   color: var(--color-gray-4);
   font-size: 0.75rem;
-}
-
-.recruiting-detail-evaluation-score {
-  color: var(--color-green-0);
-  font-weight: 500;
 }
 
 .recruiting-detail-toggle-btn {

--- a/src/components/pages/RecruitingDetail/detail/ApplicantResponsive.css
+++ b/src/components/pages/RecruitingDetail/detail/ApplicantResponsive.css
@@ -107,8 +107,7 @@
     color: var(--color-gray-3);
   }
   
-  .recruiting-detail-applicant-score,
-  .recruiting-detail-evaluation-score {
+  .recruiting-detail-applicant-score {
     font-size: 0.7rem;
   }
   
@@ -246,8 +245,7 @@
     font-size: 0.75rem;
   }
   
-  .recruiting-detail-applicant-score,
-  .recruiting-detail-evaluation-score {
+  .recruiting-detail-applicant-score {
     font-size: 0.75rem;
   }
   
@@ -360,8 +358,7 @@
   }
   
   .recruiting-detail-applied-date,
-  .recruiting-detail-applicant-score,
-  .recruiting-detail-evaluation-score {
+  .recruiting-detail-applicant-score {
     font-size: 0.65rem;
   }
   

--- a/src/components/pages/RecruitingDetail/modals/BulkStatusChangeModal.css
+++ b/src/components/pages/RecruitingDetail/modals/BulkStatusChangeModal.css
@@ -141,6 +141,124 @@
   gap: 1rem;
 }
 
+/* 순위 선택 섹션 */
+.bulk-change-modal__ranking-type-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.bulk-change-modal__ranking-type-label {
+  color: var(--color-white);
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.bulk-change-modal__ranking-type-options {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.bulk-change-modal__ranking-type-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  border: 1px solid var(--color-gray-5);
+  background-color: transparent;
+  color: var(--color-gray-2);
+  font-size: 0.875rem;
+  font-weight: 500;
+  transition: all 0.3s ease;
+  min-width: 140px;
+  position: relative;
+}
+
+.bulk-change-modal__ranking-type-option:hover {
+  border-color: var(--color-green-0);
+  background-color: rgba(34, 197, 94, 0.1);
+}
+
+.bulk-change-modal__ranking-type-option--selected {
+  border-color: var(--color-green-0);
+  background: linear-gradient(135deg, rgba(34, 197, 94, 0.15) 0%, rgba(34, 197, 94, 0.08) 100%);
+  color: var(--color-white);
+  box-shadow: 0 0 0 1px rgba(34, 197, 94, 0.2);
+}
+
+.bulk-change-modal__ranking-type-option--disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.bulk-change-modal__ranking-type-option--disabled:hover {
+  border-color: var(--color-gray-5);
+  background-color: transparent;
+}
+
+.bulk-change-modal__ranking-type-radio {
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border: 2px solid var(--color-gray-4);
+  border-radius: 50%;
+  position: relative;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  background-color: var(--color-gray-7);
+  flex-shrink: 0;
+}
+
+.bulk-change-modal__ranking-type-radio:checked {
+  border-color: var(--color-green-0);
+  background-color: var(--color-green-0);
+  box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.2);
+}
+
+.bulk-change-modal__ranking-type-radio:checked::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: var(--color-white);
+  animation: radioCheck 0.2s ease;
+}
+
+.bulk-change-modal__ranking-type-radio:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.2);
+}
+
+.bulk-change-modal__ranking-type-radio:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.bulk-change-modal__ranking-type-text {
+  font-weight: 500;
+  user-select: none;
+  transition: color 0.3s ease;
+}
+
+@keyframes radioCheck {
+  0% {
+    transform: translate(-50%, -50%) scale(0);
+    opacity: 0;
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 1;
+  }
+}
+
 .bulk-status-label {
   color: var(--color-white);
   font-size: 0.875rem;
@@ -280,9 +398,36 @@
     gap: 1.5rem;
   }
 
+  .bulk-change-modal__ranking-type-label,
   .bulk-count-label,
   .bulk-status-label {
     font-size: 0.8rem;
+  }
+
+  .bulk-change-modal__ranking-type-section {
+    gap: 0.75rem;
+  }
+
+  .bulk-change-modal__ranking-type-options {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .bulk-change-modal__ranking-type-option {
+    min-width: auto;
+    width: 100%;
+    padding: 0.625rem 0.875rem;
+    font-size: 0.8rem;
+  }
+
+  .bulk-change-modal__ranking-type-radio {
+    width: 16px;
+    height: 16px;
+  }
+
+  .bulk-change-modal__ranking-type-radio:checked::after {
+    width: 6px;
+    height: 6px;
   }
 
   .bulk-count-input-wrapper {
@@ -362,9 +507,36 @@
     gap: 0.625rem;
   }
 
+  .bulk-change-modal__ranking-type-label,
   .bulk-count-label,
   .bulk-status-label {
     font-size: 0.75rem;
+  }
+
+  .bulk-change-modal__ranking-type-section {
+    gap: 0.625rem;
+  }
+
+  .bulk-change-modal__ranking-type-options {
+    flex-direction: column;
+    gap: 0.625rem;
+  }
+
+  .bulk-change-modal__ranking-type-option {
+    min-width: auto;
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    font-size: 0.75rem;
+  }
+
+  .bulk-change-modal__ranking-type-radio {
+    width: 15px;
+    height: 15px;
+  }
+
+  .bulk-change-modal__ranking-type-radio:checked::after {
+    width: 5px;
+    height: 5px;
   }
 
   .bulk-count-input-wrapper {
@@ -451,9 +623,36 @@
     gap: 0.5rem;
   }
 
+  .bulk-change-modal__ranking-type-label,
   .bulk-count-label,
   .bulk-status-label {
     font-size: 0.7rem;
+  }
+
+  .bulk-change-modal__ranking-type-section {
+    gap: 0.5rem;
+  }
+
+  .bulk-change-modal__ranking-type-options {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .bulk-change-modal__ranking-type-option {
+    min-width: auto;
+    width: 100%;
+    padding: 0.45rem 0.625rem;
+    font-size: 0.7rem;
+  }
+
+  .bulk-change-modal__ranking-type-radio {
+    width: 14px;
+    height: 14px;
+  }
+
+  .bulk-change-modal__ranking-type-radio:checked::after {
+    width: 4px;
+    height: 4px;
   }
 
   .bulk-count-input-wrapper {

--- a/src/components/pages/RecruitingDetail/modals/BulkStatusChangeModal.css
+++ b/src/components/pages/RecruitingDetail/modals/BulkStatusChangeModal.css
@@ -113,6 +113,11 @@
   text-align: center;
 }
 
+.bulk-count-input::placeholder {
+  color: var(--color-gray-4);
+  font-weight: 400;
+}
+
 .bulk-count-input:focus {
   outline: none;
   border-color: var(--color-green-0);

--- a/src/components/pages/RecruitingDetail/modals/BulkStatusChangeModal.jsx
+++ b/src/components/pages/RecruitingDetail/modals/BulkStatusChangeModal.jsx
@@ -15,7 +15,22 @@ const BulkStatusChangeModal = ({
   if (!isOpen) return null;
 
   const handleCountChange = (e) => {
-    setBulkChangeCount(Math.max(1, parseInt(e.target.value) || 1));
+    const value = e.target.value;
+    // 입력 중에는 자유롭게 허용 (빈 값, 0 포함)
+    if (value === '' || value === '0') {
+      setBulkChangeCount(value);
+    } else {
+      const numValue = parseInt(value) || 0;
+      setBulkChangeCount(Math.min(numValue, 1000)); // 최대값 제한만 적용
+    }
+  };
+
+  const handleCountBlur = () => {
+    // blur 시에만 최소값 보정
+    const numValue = parseInt(bulkChangeCount) || 0;
+    if (numValue < 1) {
+      setBulkChangeCount(1);
+    }
   };
 
   const handleStatusClick = (passStatus) => {
@@ -93,10 +108,12 @@ const BulkStatusChangeModal = ({
                   type="number" 
                   value={bulkChangeCount}
                   onChange={handleCountChange}
+                  onBlur={handleCountBlur}
                   className="bulk-count-input"
                   min="1"
-                  max="100"
+                  max="1000"
                   disabled={isBulkChanging}
+                  placeholder="인원 수 입력"
                 />
                 <span className="bulk-count-suffix">명</span>
               </div>

--- a/src/components/pages/RecruitingDetail/modals/BulkStatusChangeModal.jsx
+++ b/src/components/pages/RecruitingDetail/modals/BulkStatusChangeModal.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import './BulkStatusChangeModal.css';
 
 const BulkStatusChangeModal = ({
@@ -7,17 +7,23 @@ const BulkStatusChangeModal = ({
   bulkChangeCount,
   setBulkChangeCount,
   isBulkChanging,
-  onStatusChange
+  onStatusChange,
+  onBottomStatusChange
 }) => {
+  const [rankingType, setRankingType] = useState('TOP'); // 'TOP' | 'BOTTOM'
+  
   if (!isOpen) return null;
 
   const handleCountChange = (e) => {
     setBulkChangeCount(Math.max(1, parseInt(e.target.value) || 1));
   };
 
-
   const handleStatusClick = (passStatus) => {
-    onStatusChange(passStatus);
+    if (rankingType === 'TOP') {
+      onStatusChange && onStatusChange(passStatus);
+    } else {
+      onBottomStatusChange && onBottomStatusChange(passStatus);
+    }
   };
 
   return (
@@ -35,10 +41,48 @@ const BulkStatusChangeModal = ({
         </div>
         <div className="bulk-change-modal-content">
           <div className="bulk-change-description">
-            평가 점수를 기준으로 상위 지원자들의 상태를 일괄 변경합니다.
+            평가 점수를 기준으로 {rankingType === 'TOP' ? '상위' : '하위'} 지원자들의 상태를 일괄 변경합니다.
           </div>
           
           <div className="bulk-change-controls">
+            <div className="bulk-change-modal__ranking-type-section">
+              <label className="bulk-change-modal__ranking-type-label">선택 기준</label>
+              <div className="bulk-change-modal__ranking-type-options">
+                <label className={`bulk-change-modal__ranking-type-option ${
+                  rankingType === 'TOP' ? 'bulk-change-modal__ranking-type-option--selected' : ''
+                } ${
+                  isBulkChanging ? 'bulk-change-modal__ranking-type-option--disabled' : ''
+                }`}>
+                  <input 
+                    type="radio" 
+                    name="rankingType" 
+                    value="TOP"
+                    checked={rankingType === 'TOP'}
+                    onChange={(e) => setRankingType(e.target.value)}
+                    disabled={isBulkChanging}
+                    className="bulk-change-modal__ranking-type-radio"
+                  />
+                  <span className="bulk-change-modal__ranking-type-text">상위 (점수 높은 순)</span>
+                </label>
+                <label className={`bulk-change-modal__ranking-type-option ${
+                  rankingType === 'BOTTOM' ? 'bulk-change-modal__ranking-type-option--selected' : ''
+                } ${
+                  isBulkChanging ? 'bulk-change-modal__ranking-type-option--disabled' : ''
+                }`}>
+                  <input 
+                    type="radio" 
+                    name="rankingType" 
+                    value="BOTTOM"
+                    checked={rankingType === 'BOTTOM'}
+                    onChange={(e) => setRankingType(e.target.value)}
+                    disabled={isBulkChanging}
+                    className="bulk-change-modal__ranking-type-radio"
+                  />
+                  <span className="bulk-change-modal__ranking-type-text">하위 (점수 낮은 순)</span>
+                </label>
+              </div>
+            </div>
+
             <div className="bulk-count-section">
               <label htmlFor="bulk-count" className="bulk-count-label">
                 변경할 인원수

--- a/src/components/recruiting/applicant/ApplicantCard.jsx
+++ b/src/components/recruiting/applicant/ApplicantCard.jsx
@@ -163,11 +163,8 @@ const ApplicantCard = memo(({
           <div className="recruiting-detail-applicant-right-info">
             <span className="recruiting-detail-applied-date">{applicant.appliedDate}</span>
             <span className="recruiting-detail-applicant-score">
-              AI 점수: {isLoadingAi ? '로딩중...' : aiSummary?.scoreOutOf100 ? `${aiSummary.scoreOutOf100}점` : '분석 대기'}
+              평균 점수: {applicant.averageScore}점
             </span>
-            {evaluation && (
-              <span className="recruiting-detail-evaluation-score">평가: {evaluation.score}점</span>
-            )}
           </div>
         </div>
         
@@ -241,7 +238,7 @@ const ApplicantCard = memo(({
               <h4 className="section-subtitle">💬 평가 ({allEvaluations.length})</h4>
               <div className="ai-score">
                 <Star size={16} className="star-icon" />
-                <span>AI 점수: {isLoadingAi ? '로딩중...' : aiSummary?.scoreOutOf100 ? `${aiSummary.scoreOutOf100}점` : '분석 대기'}</span>
+                <span>평균 점수: {applicant.averageScore}점</span>
               </div>
             </div>
             

--- a/src/components/recruiting/applicant/ApplicantFilters.jsx
+++ b/src/components/recruiting/applicant/ApplicantFilters.jsx
@@ -39,10 +39,10 @@ const ApplicantFilters = ({
         onChange={(e) => onSortChange(e.target.value)}
         className="sort-filter"
       >
-        <option value={SORT_OPTIONS.APPLICATION_DATE}>지원순</option>
-        <option value={SORT_OPTIONS.AI_SCORE}>AI 스코어순</option>
-        <option value={SORT_OPTIONS.EVALUATION_SCORE}>채점 스코어순</option>
+        <option value={SORT_OPTIONS.AI_EVALUATION_SCORE}>AI 평가 점수순</option>
+        <option value={SORT_OPTIONS.AVERAGE_SCORE}>평균 점수순</option>
         <option value={SORT_OPTIONS.NAME}>이름순</option>
+        <option value={SORT_OPTIONS.APPLICATION_DATE}>지원순</option>
       </select>
     </div>
   );

--- a/src/constants/recruitment.js
+++ b/src/constants/recruitment.js
@@ -47,8 +47,8 @@ export const PASS_STATUS_KOREAN = {
 };
 
 export const SORT_OPTIONS = {
-  AI_SCORE: 'AI스코어순',
-  EVALUATION_SCORE: '채점스코어순',
+  AI_EVALUATION_SCORE: 'AI평가점수순',
+  AVERAGE_SCORE: '평균점수순',
   NAME: '이름순',
   APPLICATION_DATE: '지원순',
 };

--- a/src/hooks/business/useBulkActions.js
+++ b/src/hooks/business/useBulkActions.js
@@ -5,12 +5,13 @@ export const useBulkActions = (formStates, loadingStates, refetchApplications, g
   const { isBulkChanging, setIsBulkChanging } = loadingStates;
 
   const changeTopNStatus = async (passStatus) => {
-    if (!bulkChangeCount || bulkChangeCount <= 0) {
-      alert('변경할 인원 수를 올바르게 입력해주세요.');
-      return { success: false, message: '올바른 인원 수를 입력해주세요.' };
+    const numValue = parseInt(bulkChangeCount) || 0;
+    if (!bulkChangeCount || numValue <= 0) {
+      alert('변경할 인원 수를 1 이상으로 입력해주세요.');
+      return { success: false, message: '변경할 인원 수를 1 이상으로 입력해주세요.' };
     }
 
-    const confirmMessage = `상위 ${bulkChangeCount}명을 "${passStatus}"로 변경하시겠습니까?`;
+    const confirmMessage = `상위 ${numValue}명을 "${passStatus}"로 변경하시겠습니까?`;
     if (!window.confirm(confirmMessage)) {
       return { success: false, message: '사용자가 취소했습니다.' };
     }
@@ -18,10 +19,10 @@ export const useBulkActions = (formStates, loadingStates, refetchApplications, g
     setIsBulkChanging(true);
     
     try {
-      const result = await applicationStatusAPI.bulkChangeApplicationStatus(googleFormId, bulkChangeCount, passStatus);
+      const result = await applicationStatusAPI.bulkChangeApplicationStatus(googleFormId, numValue, passStatus);
       
       if (result.success) {
-        alert(`상위 ${bulkChangeCount}명의 상태가 성공적으로 변경되었습니다.`);
+        alert(`상위 ${numValue}명의 상태가 성공적으로 변경되었습니다.`);
         
         // 애플리케이션 데이터 새로고침
         if (refetchApplications) {
@@ -51,12 +52,13 @@ export const useBulkActions = (formStates, loadingStates, refetchApplications, g
   };
 
   const changeBottomNStatus = async (passStatus) => {
-    if (!bulkChangeCount || bulkChangeCount <= 0) {
-      alert('변경할 인원 수를 올바르게 입력해주세요.');
-      return { success: false, message: '올바른 인원 수를 입력해주세요.' };
+    const numValue = parseInt(bulkChangeCount) || 0;
+    if (!bulkChangeCount || numValue <= 0) {
+      alert('변경할 인원 수를 1 이상으로 입력해주세요.');
+      return { success: false, message: '변경할 인원 수를 1 이상으로 입력해주세요.' };
     }
 
-    const confirmMessage = `하위 ${bulkChangeCount}명을 "${passStatus}"로 변경하시겠습니까?`;
+    const confirmMessage = `하위 ${numValue}명을 "${passStatus}"로 변경하시겠습니까?`;
     if (!window.confirm(confirmMessage)) {
       return { success: false, message: '사용자가 취소했습니다.' };
     }
@@ -64,10 +66,10 @@ export const useBulkActions = (formStates, loadingStates, refetchApplications, g
     setIsBulkChanging(true);
     
     try {
-      const result = await applicationStatusAPI.bulkChangeBottomStatus(googleFormId, bulkChangeCount, passStatus);
+      const result = await applicationStatusAPI.bulkChangeBottomStatus(googleFormId, numValue, passStatus);
       
       if (result.success) {
-        alert(`하위 ${bulkChangeCount}명의 상태가 성공적으로 변경되었습니다.`);
+        alert(`하위 ${numValue}명의 상태가 성공적으로 변경되었습니다.`);
         
         // 애플리케이션 데이터 새로고침
         if (refetchApplications) {

--- a/src/hooks/business/useBulkActions.js
+++ b/src/hooks/business/useBulkActions.js
@@ -1,6 +1,6 @@
 import { applicationStatusAPI } from '../../services/api/index.js';
 
-export const useBulkActions = (formStates, loadingStates, refetchApplications) => {
+export const useBulkActions = (formStates, loadingStates, refetchApplications, googleFormId) => {
   const { bulkChangeCount } = formStates;
   const { isBulkChanging, setIsBulkChanging } = loadingStates;
 
@@ -18,7 +18,7 @@ export const useBulkActions = (formStates, loadingStates, refetchApplications) =
     setIsBulkChanging(true);
     
     try {
-      const result = await applicationStatusAPI.bulkChangeApplicationStatus(bulkChangeCount, passStatus);
+      const result = await applicationStatusAPI.bulkChangeApplicationStatus(googleFormId, bulkChangeCount, passStatus);
       
       if (result.success) {
         alert(`상위 ${bulkChangeCount}명의 상태가 성공적으로 변경되었습니다.`);
@@ -40,6 +40,52 @@ export const useBulkActions = (formStates, loadingStates, refetchApplications) =
         message = '잘못된 요청입니다. 인원 수나 상태를 확인해주세요.';
       } else if (error.response?.status === 403) {
         message = '권한이 없습니다. 관리자에게 문의해주세요.';
+      } else if (error.response?.data?.message) {
+        message = error.response.data.message;
+      }
+      
+      return { success: false, error, message };
+    } finally {
+      setIsBulkChanging(false);
+    }
+  };
+
+  const changeBottomNStatus = async (passStatus) => {
+    if (!bulkChangeCount || bulkChangeCount <= 0) {
+      alert('변경할 인원 수를 올바르게 입력해주세요.');
+      return { success: false, message: '올바른 인원 수를 입력해주세요.' };
+    }
+
+    const confirmMessage = `하위 ${bulkChangeCount}명을 "${passStatus}"로 변경하시겠습니까?`;
+    if (!window.confirm(confirmMessage)) {
+      return { success: false, message: '사용자가 취소했습니다.' };
+    }
+
+    setIsBulkChanging(true);
+    
+    try {
+      const result = await applicationStatusAPI.bulkChangeBottomStatus(googleFormId, bulkChangeCount, passStatus);
+      
+      if (result.success) {
+        alert(`하위 ${bulkChangeCount}명의 상태가 성공적으로 변경되었습니다.`);
+        
+        // 애플리케이션 데이터 새로고침
+        if (refetchApplications) {
+          await refetchApplications();
+        }
+        
+        return { success: true };
+      } else {
+        return { success: false, message: result.message || '상태 변경에 실패했습니다.' };
+      }
+    } catch (error) {
+      // 에러는 이미 apiClient에서 로깅됨
+      
+      let message = '상태 변경 중 오류가 발생했습니다.';
+      if (error.response?.status === 400) {
+        message = '잘못된 요청입니다. 인원 수나 상태를 확인해주세요.';
+      } else if (error.response?.status === 403) {
+        message = 'Root 권한이 필요합니다. 관리자에게 문의해주세요.';
       } else if (error.response?.data?.message) {
         message = error.response.data.message;
       }
@@ -88,6 +134,7 @@ export const useBulkActions = (formStates, loadingStates, refetchApplications) =
 
   return {
     changeTopNStatus,
+    changeBottomNStatus,
     changeApplicationStatus,
     isBulkChanging
   };

--- a/src/hooks/legacy/useRecruitingData.js
+++ b/src/hooks/legacy/useRecruitingData.js
@@ -118,7 +118,7 @@ export const useRecruitingData = (id) => {
                         app.passStatus === 'FIRST_PASS' ? 'blue' :
                         app.passStatus === 'FAILED' ? 'red' :
                         app.passStatus === 'PENDING' ? 'yellow' : 'yellow',
-            aiScore: 0, // AI Summary API에서 가져올 예정
+            averageScore: app.averageScore || 0, // API에서 제공하는 평균 점수 사용
             skills: [app.major, app.department].filter(Boolean), // 전공여부와 학과를 스킬로 표시
             portfolio: formData['포트폴리오'] || formData['포트폴리오 링크'] || '',
             application: fullApplication, // 전체 지원서 데이터

--- a/src/hooks/useStateManagement.js
+++ b/src/hooks/useStateManagement.js
@@ -7,7 +7,7 @@ import { useCSVExport } from './business/useCSVExport';
 import { useEmailActions } from './business/useEmailActions';
 import { useBulkActions } from './business/useBulkActions';
 
-export const useStateManagement = (recruitingInfo, refetchRecruitingInfo, refetchApplications, allApplicants) => {
+export const useStateManagement = (recruitingInfo, refetchRecruitingInfo, refetchApplications, allApplicants, googleFormId) => {
   // 상태 훅들
   const modalStates = useModalStates();
   const loadingStates = useLoadingStates();
@@ -17,7 +17,7 @@ export const useStateManagement = (recruitingInfo, refetchRecruitingInfo, refetc
   const recruitingActions = useRecruitingActions(recruitingInfo, refetchRecruitingInfo, loadingStates);
   const csvExport = useCSVExport(recruitingInfo, allApplicants, loadingStates);
   const emailActions = useEmailActions(formStates, loadingStates, modalStates);
-  const bulkActions = useBulkActions(formStates, loadingStates, refetchApplications);
+  const bulkActions = useBulkActions(formStates, loadingStates, refetchApplications, googleFormId);
 
   // 편집 관련 함수들
   const startEdit = (field, currentValue) => {
@@ -76,6 +76,7 @@ export const useStateManagement = (recruitingInfo, refetchRecruitingInfo, refetc
     // 상태 변경 함수들
     changeApplicationStatus: bulkActions.changeApplicationStatus,
     changeTopNStatus: bulkActions.changeTopNStatus,
+    changeBottomNStatus: bulkActions.changeBottomNStatus,
     
     // 리쿠르팅 관리 함수들
     changeStatus: recruitingActions.handleChangeStatus,

--- a/src/pages/RecruitingDetailPage.jsx
+++ b/src/pages/RecruitingDetailPage.jsx
@@ -55,6 +55,7 @@ const RecruitingDetailPageInner = () => {
     subscriberCount,
     changeApplicationStatus,
     changeTopNStatus,
+    changeBottomNStatus,
     changeStatus,
     deleteRecruiting,
     startEdit,
@@ -69,7 +70,7 @@ const RecruitingDetailPageInner = () => {
     closeBulkModal,
     showDeleteModalWithCheck,
     closeDeleteModal
-  } = useStateManagement(recruitingInfo, refetchRecruitingInfo, refetchApplications, allApplicants);
+  } = useStateManagement(recruitingInfo, refetchRecruitingInfo, refetchApplications, allApplicants, recruitingInfo?.id);
   
   // UI 상태 (Context로 이동한 것들은 제거)
   const [showRecruitingDetails, setShowRecruitingDetails] = useState(false);
@@ -200,6 +201,14 @@ const RecruitingDetailPageInner = () => {
   // 점수 기준 상위 N명 상태 변경
   const handleTopNStatusChange = async (passStatus) => {
     const result = await changeTopNStatus(passStatus);
+    if (!result.success && !result.cancelled) {
+      alert(result.message);
+    }
+  };
+
+  // 점수 기준 하위 N명 상태 변경
+  const handleBottomNStatusChange = async (passStatus) => {
+    const result = await changeBottomNStatus(passStatus);
     if (!result.success && !result.cancelled) {
       alert(result.message);
     }
@@ -400,6 +409,7 @@ const RecruitingDetailPageInner = () => {
         setBulkChangeCount={setBulkChangeCount}
         isBulkChanging={isBulkChanging}
         onStatusChange={handleTopNStatusChange}
+        onBottomStatusChange={handleBottomNStatusChange}
       />
     </div>
   );

--- a/src/services/api/core/apiClient.js
+++ b/src/services/api/core/apiClient.js
@@ -2,8 +2,8 @@ import axios from 'axios';
 import logger from '../../../utils/logger';
 
 // API 기본 설정
-// const API_BASE_URL = 'http://localhost:8080';
-const API_BASE_URL = 'https://api.piro-recruiting.kro.kr';
+const API_BASE_URL = 'http://localhost:8080';
+// const API_BASE_URL = 'https://api.piro-recruiting.kro.kr';
 
 // axios 인스턴스 생성
 const apiClient = axios.create({

--- a/src/services/api/domains/applications/applicationStatusAPI.js
+++ b/src/services/api/domains/applications/applicationStatusAPI.js
@@ -6,8 +6,15 @@ export const applicationStatusAPI = {
     return response.data;
   },
 
-  bulkChangeApplicationStatus: async (topN, passStatus) => {
-    const response = await apiClient.post(`/api/webhook/applications/bulk-status?topN=${topN}&passStatus=${passStatus}`);
+  // 구글 폼별 상위 N명 상태 변경
+  bulkChangeApplicationStatus: async (googleFormId, topN, passStatus) => {
+    const response = await apiClient.post(`/api/webhook/applications/google-form/${googleFormId}/bulk-status?topN=${topN}&passStatus=${passStatus}`);
+    return response.data;
+  },
+
+  // 구글 폼별 하위 N명 상태 변경
+  bulkChangeBottomStatus: async (googleFormId, bottomN, passStatus) => {
+    const response = await apiClient.post(`/api/webhook/applications/google-form/${googleFormId}/bulk-status-bottom?bottomN=${bottomN}&passStatus=${passStatus}`);
     return response.data;
   }
 };

--- a/src/utils/sort.js
+++ b/src/utils/sort.js
@@ -12,7 +12,7 @@ export const sortApplicants = (applicants, sortBy, evaluations) => {
   
   switch (sortBy) {
     case SORT_OPTIONS.AI_SCORE:
-      return sorted.sort((a, b) => b.aiScore - a.aiScore);
+      return sorted.sort((a, b) => b.averageScore - a.averageScore);
       
     case SORT_OPTIONS.EVALUATION_SCORE:
       return sorted.sort((a, b) => {

--- a/src/utils/sort.js
+++ b/src/utils/sort.js
@@ -11,15 +11,17 @@ export const sortApplicants = (applicants, sortBy, evaluations) => {
   const sorted = [...applicants];
   
   switch (sortBy) {
-    case SORT_OPTIONS.AI_SCORE:
-      return sorted.sort((a, b) => b.averageScore - a.averageScore);
-      
-    case SORT_OPTIONS.EVALUATION_SCORE:
+    case SORT_OPTIONS.AI_EVALUATION_SCORE:
+      // AI 평가 점수 정렬 (AI가 매긴 점수)
       return sorted.sort((a, b) => {
-        const aScore = evaluations[a.id]?.score || 0;
-        const bScore = evaluations[b.id]?.score || 0;
-        return bScore - aScore;
+        const aAiScore = a.aiSummary?.scoreOutOf100 || 0;
+        const bAiScore = b.aiSummary?.scoreOutOf100 || 0;
+        return bAiScore - aAiScore;
       });
+      
+    case SORT_OPTIONS.AVERAGE_SCORE:
+      // 평균 점수 정렬 (사람들이 매긴 평가의 평균)
+      return sorted.sort((a, b) => b.averageScore - a.averageScore);
       
     case SORT_OPTIONS.NAME:
       return sorted.sort((a, b) => a.name.localeCompare(b.name));


### PR DESCRIPTION
  Summary

  일괄 상태 변경 모달의 사용자 경험을 개선하고, 지원서 점수 표시
  시스템을 API 응답 구조에 맞게 정리했습니다.

  ✨ 주요 개선사항

  🔧 일괄 상태 변경 모달 UX 개선

  - 자연스러운 입력 경험: 인원 수 입력 시 0이나 빈 값을 자유롭게 입력       
  가능
  - 단계별 검증: 입력 중→포커스 해제→API 호출 단계로 나누어 적절한
  시점에 검증
  - 플레이스홀더 추가: "인원 수 입력" 힌트 제공
  - 최대값 확장: 100명 → 1000명으로 대용량 처리 대비

  📊 점수 표시 시스템 정리

  - API 연동: averageScore 필드를 활용한 실제 평균 점수 표시
  - 중복 제거: 요약 카드의 중복 평가 점수 표시 제거
  - 변수명 일관성: aiScore → averageScore로 의미에 맞게 수정

  🔄 정렬 시스템 개선

  - 명확한 구분: AI 평가 점수와 평균 점수를 별도 정렬 옵션으로 분리
  - 올바른 순서: AI 평가 점수순 → 평균 점수순 → 이름순 → 지원순
  - 내림차순 정렬: 점수 관련 정렬은 모두 높은 점수부터 표시

  🗂️ 변경된 파일

  - UI 컴포넌트: BulkStatusChangeModal, ApplicantCard, ApplicantFilters     
  - 비즈니스 로직: useBulkActions, useRecruitingData, sort utilities        
  - 스타일: CSS 정리 및 불필요한 스타일 제거
  - 상수: 정렬 옵션 정리 및 명명 개선